### PR TITLE
Fix bugs in read and write functions about strokeColor, fillColor, and position

### DIFF
--- a/R/read.ijroi.R
+++ b/R/read.ijroi.R
@@ -77,7 +77,7 @@ read.ijroi <- function(file, verbose=FALSE) {
 
   getInt <- function(con)  {
     pos <- seek(con)
-    n <- readBin(con, integer(0), 1, size=4, signed=TRUE, endian="little")
+    n <- readBin(con, integer(0), 1, size=4, signed=TRUE, endian="big")
     if (verbose)
       message(paste("Pos ", pos , ": Integer ", n, sep=""))
     return (n);
@@ -158,8 +158,19 @@ read.ijroi <- function(file, verbose=FALSE) {
   r$y2 <-           getFloat(con)
   r$strokeWidth <-  getShort(con)  # 34-35 stroke width (v1.43i or later) STROKE_WIDTH
   r$shapeRoiSize <- getInt(con)    # 36-39 ShapeRoi size (type must be 1 if this value>0) SHAPE_ROI_SIZE
-  r$strokeColor <-  getInt(con)    # 40-43 stroke color (v1.43i or later)
-  r$fillColor <-    getInt(con)    # 44-47 fill color (v1.43i or later) FILL_COLOR
+  
+  #r$strokeColor <-  getInt(con)    # 40-43 stroke color (v1.43i or later)
+  r$strokeColor_a <-  getByte(con)    # 40
+  r$strokeColor_r <-  getByte(con)    # 41
+  r$strokeColor_g <-  getByte(con)    # 42
+  r$strokeColor_b <-  getByte(con)    # 43
+  
+  #r$fillColor <-    getInt(con)    # 44-47 fill color (v1.43i or later) FILL_COLOR
+  r$fillColor_a <-    getByte(con)    # 44
+  r$fillColor_r <-    getByte(con)    # 45
+  r$fillColor_g <-    getByte(con)    # 46
+  r$fillColor_b <-    getByte(con)    # 47
+  
   r$subtype <-      getShort(con)  # 48-49 subtype (v1.43k or later)    SUBTYPE
   r$options <-      getShort(con)  # 50-51 options (v1.43k or later)    OPTIONS
   ## 52-55   style information or aspect ratio (v1.43p or later)

--- a/R/write.ijroi.R
+++ b/R/write.ijroi.R
@@ -26,7 +26,7 @@ write.ijroi <- function(file, roi, verbose = TRUE) {
 
   putInt <- function(con, input) {
     pos <- seek(con)
-    writeBin(object = as.integer(input), con = con, size = 4, endian = "little")
+    writeBin(object = as.integer(input), con = con, size = 4, endian = "big")
     if(verbose) {
       message(paste0("Pos ", pos, "-", pos+3, ": Integer ", input))
     }
@@ -80,8 +80,19 @@ write.ijroi <- function(file, roi, verbose = TRUE) {
 
   putShort(con, roi$strokeWidth) # 34-35 stroke width
   putInt(con, roi$shapeRoiSize) # 36-39 ShapeRoi size
-  putInt(con, roi$strokeColor) # 40-43 stroke color
-  putInt(con, roi$fillColor) # 44-47 fill color
+  
+  #putInt(con, roi$strokeColor) # 40-43 stroke color
+  putByte(con, roi$strokeColor_a) # 40 alpha channel
+  putByte(con, roi$strokeColor_r) # 41 red channel
+  putByte(con, roi$strokeColor_g) # 42 green channel
+  putByte(con, roi$strokeColor_b) # 43 blue channel
+  
+  #putInt(con, roi$fillColor) # 44-47 fill color
+  putByte(con, roi$fillColor_a) # 44 alpha channel
+  putByte(con, roi$fillColor_r) # 45 red channel
+  putByte(con, roi$fillColor_g) # 46 green channel
+  putByte(con, roi$fillColor_b) # 47 blue channel
+  
   putShort(con, roi$subtype) # 48-49 subtype
   putShort(con, roi$options) # 50-51 options
 


### PR DESCRIPTION
Hi, David,
Recently, I dealt with roi files in a stack image and found some bugs in the source code.

1. strokeColor and fillColor are encoded as 32 bit unsigned integer (A, R, G, B) in ImageJ. However, in R, 32 bit integer can only be written in singned mode, which causes error in encoding and decoding the color. To overcome this problem, I chose to encode and decode strokeColor and fillColor using four bytes, parsing alpha, red, green, and blue channels, respectively.

2. "position" is an important property when I dealt with a stack image, which indicates the index of slices of the roi. It is encoded as 32 bit unsigned integer with big-endian in ImageJ. But, now we used "little-endian", which gets the wrong value.

I also uploaded a demo_stack and roi file on slice 42 (https://drive.google.com/drive/folders/1ouCkL7eY-JnYYG49JAdCmoWEIJ7s1_qO?usp=drive_link). You can double check it. 

Best regards

Le